### PR TITLE
Apply CGI.escape to non-array non-form values

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -174,7 +174,7 @@ module Rswag
               return "#{escaped_name}=" + value.to_a.flatten.map{|v| CGI.escape(v.to_s) }.join(separator)
             end
           else
-            return "#{name}=#{value}"
+            return "#{name}=#{CGI.escape(value)}"
           end
         end
 

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -88,6 +88,21 @@ module Rswag
             expect(request[:path]).to eq('/blogs?q1=foo&q2=bar')
           end
 
+          context 'when escaping is needed' do
+            before do
+              metadata[:operation][:parameters] = [
+                { name: 'q1', in: :query, type: :string },
+                { name: 'q2', in: :query, type: :string }
+              ]
+              allow(example).to receive(:q1).and_return('order #123')
+              allow(example).to receive(:q2).and_return('last % ditch')
+            end
+
+            it 'builds the query string from example values with encoding' do
+              expect(request[:path]).to eq('/blogs?q1=foo&q2=bar')
+            end
+          end
+
           context 'when `getter is defined`' do
             before do
               metadata[:operation][:parameters] << {


### PR DESCRIPTION
## Problem
A string query param described in an rswag integration spec gets escaped in `rspec` tests and doesn't get escaped in rswag non-dry run.

## Solution
Apply the same array and form escaping to everything else.


### The changes I made are compatible with:
- [X] OAS2
- [X] OAS3
- [X] OAS3.1

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
1. Have a query param called `x` that is a string and contains a `#`, for example: `?filter[description]=Order for #231`
2. Run the test and inspect the params in the controller